### PR TITLE
Split out calc_benefits script and merge fullsimulate_with_events

### DIFF
--- a/scripts/calc_benefits.jl
+++ b/scripts/calc_benefits.jl
@@ -1,4 +1,4 @@
-include("src/calc_benefits.jl")
+include("../src/calc_benefits.jl")
 
 SS = 36
 mcdraws = 100

--- a/scripts/calc_benefits.jl
+++ b/scripts/calc_benefits.jl
@@ -1,0 +1,73 @@
+include("src/calc_benefits.jl")
+
+SS = 36
+mcdraws = 100
+dt0 = DateTime("2023-07-17T12:00:00")
+drive_starts_time = Time(9, 0, 0)  # Example drive start time
+park_starts_time = Time(17, 0, 0)  # Example park start time
+
+
+# First, run the stochastic simulation to develop strategy for charging with stochastic events
+benefits_stoch, strat = run_optimized_stochastic_simulation(dt0, SS, mcdraws, drive_starts_time, park_starts_time)
+
+# # Then, run a bunch of simulations to calculate mean benefits under optimal strategy and rule of thumb with events
+mean_benefits_optimized, mean_benefits_rot, mean_benefits_rot_baseline = run_rule_of_thumb_stochastic_events_simulation(dt0, strat, mcdraws, drive_starts_time, park_starts_time)
+
+println("Stochastic Optimized Benefits mean: ", mean_benefits_optimized)
+println("Stochastic Rule of Thumb Benefits mean: ", mean_benefits_rot)
+println("Baseline Rule of Thumb Benefits mean: ", mean_benefits_rot_baseline)
+
+
+## create heat map of value for parking and starting driving at different times
+test_start_times = [Time(h, 0, 0) for h in 0:23]
+test_park_times = [Time(h, 0, 0) for h in 0:23]
+
+benefits_dict = Dict{String, Dict{String, Tuple{Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}}}}()
+
+for drive_starts_time in test_start_times
+    benefits_dict[string(drive_starts_time)] = Dict()
+    for park_starts_time in test_park_times
+        if park_starts_time <= drive_starts_time
+            benefits_dict[string(drive_starts_time)][string(park_starts_time)] = (missing, missing, missing, missing, missing)
+            continue
+        end
+        rule_benefits = run_rule_of_thumb_simulation(dt0, drive_starts_time, park_starts_time)
+        optimized_benefits = run_optimized_simulation(dt0, SS, drive_starts_time, park_starts_time)
+        benefits_stoch, strat = run_optimized_stochastic_simulation(dt0, SS, mcdraws, drive_starts_time, park_starts_time)
+        mean_benefits_optimized, mean_benefits_rot, mean_benefits_rot_baseline = run_rule_of_thumb_stochastic_events_simulation(dt0, strat, mcdraws, drive_starts_time, park_starts_time)
+
+
+        benefits_dict[string(drive_starts_time)][string(park_starts_time)] = (rule_benefits, optimized_benefits, mean_benefits_optimized, mean_benefits_rot, mean_benefits_rot_baseline)
+    end
+end
+using Serialization
+
+# write it out
+open("benefits_dict.bin", "w") do io
+    serialize(io, benefits_dict)
+end
+
+# # later, to read it back:
+# using Serialization
+
+# io = open("benefits_dict.bin", "r")
+# benefits_dict_restored = deserialize(io)
+# close(io)
+# Export to LaTeX
+# export_to_latex_benefits_table(benefits_dict)
+
+# Call the plotting function using precomputed benefits and save the heatmap
+plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Rule of Thumb", 1)
+savefig("benefits_rot.png")
+
+plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Optimized", 2)
+savefig("benefits_optimized.png")
+
+plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Stochastic Optimized", 3)
+savefig("benefits_optimized_stoch.png")
+
+plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Stochastic Rule of Thumb", 4)
+savefig("benefits_optimized_stoch_rot.png")
+
+plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Stochastic Baseline Rule of Thumb", 5)
+savefig("benefits_optimized_stoch_rot_baseline.png")

--- a/src/calc_benefits.jl
+++ b/src/calc_benefits.jl
@@ -33,18 +33,18 @@ function run_optimized_simulation(dt0, SS, drive_starts_time, park_starts_time)
 end
 
 function run_optimized_stochastic_simulation(dt0, SS, mcdraws, drive_starts_time, park_starts_time)
-    mcdraws = 100  
+    mcdraws = 100
     @time strat, VV = optimize(dt0, SS, drive_starts_time, park_starts_time);
-    
+
     df = fullsimulate(dt0, strat, zeros(SS-1), 0., 0.5, 0.5, drive_starts_time, park_starts_time, true)
     benefits = sum(df[!, "valuep"]) ## conduct a single run for a simulation with stochastic events
-    
+
     # open("event_log_debug.txt", "w") do io ## to help with debugging print out event_log
     #     for ev in event_log
     #         println(io, ev)
     #     end
     # end
-    
+
     return benefits, strat
 end
 
@@ -58,9 +58,9 @@ function export_to_latex_benefits_table(benefits_dict)
         write(io, "\\begin{document}\n")
         write(io, "\\begin{table}[h!]\n")
         write(io, "\\centering\n")
-        
-        num_drive_starts = length(keys(benefits_dict)) ## Number of different start times 
-        
+
+        num_drive_starts = length(keys(benefits_dict)) ## Number of different start times
+
         write(io, "\\begin{tabular}{|c|" * repeat("c|", num_drive_starts + 1) * "}\n")
         write(io, "\\hline\n")
         write(io, "\\multicolumn{1}{|c|}{} & \\multicolumn{$(num_drive_starts)}{|c|}{\\textbf{Drive Start Time}} \\\\ \\hline\n")
@@ -105,25 +105,25 @@ function run_rule_of_thumb_stochastic_events_simulation(dt0, strat, mcdraws, dri
     # open("event_log_debug.txt", "r") do io
     #     for line in eachline(io)
     #         push!(event_log, eval(Meta.parse(line)))
-    #     end 
-    # end 
-    benefits_list_optimized = [] 
+    #     end
+    # end
+    benefits_list_optimized = []
     benefits_list_rot = []
     benefits_list_rot_baseline = []
-    
+
     for mc in mcdraws
-        ## first simulate stochastic events and calculate 
+        ## first simulate stochastic events and calculate
         df = fullsimulate(dt0, strat, zeros(SS-1), 0., 0.5, 0.5, drive_starts_time, park_starts_time)
         benefits_stoch = sum(df[!, "valuep"])
-        push!(benefits_list_optimized, benefits_stoch)        
+        push!(benefits_list_optimized, benefits_stoch)
         # pass events from event_log into rule of thumb simulation
         df = fullsimulate_with_events(dt0, (tt, state) -> get_dsoc_thumbrule1(tt, state, drive_starts_time), (tt) -> 0., 0., 0.5, 0.5, drive_starts_time, park_starts_time)
         benefits_rot = sum(df[!, "valuep"])
         push!(benefits_list_rot, benefits_rot)
         df = fullsimulate_with_events(dt0, (tt, state) -> get_dsoc_thumbrule_baseline(tt, state, drive_starts_time), (tt) -> 0., 0., 0.5, 0.5, drive_starts_time, park_starts_time)
         benefits_rot_baseline = sum(df[!, "valuep"])
-        push!(benefits_list_rot_baseline, benefits_rot_baseline)    
-    
+        push!(benefits_list_rot_baseline, benefits_rot_baseline)
+
     end
     mean_benefits_optimized = mean(benefits_list_optimized)
     mean_benefits_rot = mean(benefits_list_rot)
@@ -132,72 +132,14 @@ function run_rule_of_thumb_stochastic_events_simulation(dt0, strat, mcdraws, dri
     return mean_benefits_optimized, mean_benefits_rot, mean_benefits_rot_baseline
 end
 
-
-SS = 36
-mcdraws = 100
-dt0 = DateTime("2023-07-17T12:00:00")
-drive_starts_time = Time(9, 0, 0)  # Example drive start time
-park_starts_time = Time(17, 0, 0)  # Example park start time
-
-
-# First, run the stochastic simulation to develop strategy for charging with stochastic events
-benefits_stoch, strat = run_optimized_stochastic_simulation(dt0, SS, mcdraws, drive_starts_time, park_starts_time)
-
-# # Then, run a bunch of simulations to calculate mean benefits under optimal strategy and rule of thumb with events
-mean_benefits_optimized, mean_benefits_rot, mean_benefits_rot_baseline = run_rule_of_thumb_stochastic_events_simulation(dt0, strat, mcdraws, drive_starts_time, park_starts_time)
-
-println("Stochastic Optimized Benefits mean: ", mean_benefits_optimized)
-println("Stochastic Rule of Thumb Benefits mean: ", mean_benefits_rot)
-println("Baseline Rule of Thumb Benefits mean: ", mean_benefits_rot_baseline)
-
-
-## create heat map of value for parking and starting driving at different times
-test_start_times = [Time(h, 0, 0) for h in 0:23]
-test_park_times = [Time(h, 0, 0) for h in 0:23]
-
-benefits_dict = Dict{String, Dict{String, Tuple{Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}, Union{Float64, Missing}}}}()
-
-for drive_starts_time in test_start_times
-    benefits_dict[string(drive_starts_time)] = Dict()
-    for park_starts_time in test_park_times
-        if park_starts_time <= drive_starts_time
-            benefits_dict[string(drive_starts_time)][string(park_starts_time)] = (missing, missing, missing, missing, missing)
-            continue 
-        end
-        rule_benefits = run_rule_of_thumb_simulation(dt0, drive_starts_time, park_starts_time)
-        optimized_benefits = run_optimized_simulation(dt0, SS, drive_starts_time, park_starts_time)
-        benefits_stoch, strat = run_optimized_stochastic_simulation(dt0, SS, mcdraws, drive_starts_time, park_starts_time)
-        mean_benefits_optimized, mean_benefits_rot, mean_benefits_rot_baseline = run_rule_of_thumb_stochastic_events_simulation(dt0, strat, mcdraws, drive_starts_time, park_starts_time)
-
-
-        benefits_dict[string(drive_starts_time)][string(park_starts_time)] = (rule_benefits, optimized_benefits, mean_benefits_optimized, mean_benefits_rot, mean_benefits_rot_baseline)
-    end
-end
-using Serialization
-
-# write it out
-open("benefits_dict.bin", "w") do io
-    serialize(io, benefits_dict)
-end
-
-# # later, to read it back:
-# using Serialization
-
-# io = open("benefits_dict.bin", "r")
-# benefits_dict_restored = deserialize(io)
-# close(io)
-# Export to LaTeX
-# export_to_latex_benefits_table(benefits_dict)
-
-
 function plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict, title, index)
     # Create a 24x24 matrix for benefits, initialized with NaN
     benefit_matrix = fill(NaN, 24, 24)  # rows: drive duration (0 to 23 hours), columns: drive start hour (0 to 23)
-    
+
     for drive_start in test_start_times
         for park_start in test_park_times
             if park_starts_time <= drive_starts_time
-                continue 
+                continue
             end
 
             rule_benefits_tuple = benefits_dict[string(drive_start)][string(park_start)]
@@ -207,7 +149,7 @@ function plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, ben
             end
         end
     end
-    
+
     # Create a heatmap with drive start time on the x-axis and driving duration on the y-axis
     heatmap(0:23, 0:23, benefit_matrix,
             xlabel = "Drive Start Time (Hour)",
@@ -215,19 +157,3 @@ function plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, ben
             title = title,
             colorbar_title = "Benefit")
 end
-
-# Call the plotting function using precomputed benefits and save the heatmap
-plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Rule of Thumb", 1)
-savefig("benefits_rot.png")
-
-plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Optimized", 2)
-savefig("benefits_optimized.png")
-
-plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Stochastic Optimized", 3)
-savefig("benefits_optimized_stoch.png")
-
-plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Stochastic Rule of Thumb", 4)
-savefig("benefits_optimized_stoch_rot.png")
-
-plot_rule_of_thumb_benefits(dt0, test_start_times, test_park_times, benefits_dict_restored, "Stochastic Baseline Rule of Thumb", 5)
-savefig("benefits_optimized_stoch_rot_baseline.png")

--- a/src/calc_benefits.jl
+++ b/src/calc_benefits.jl
@@ -117,10 +117,11 @@ function run_rule_of_thumb_stochastic_events_simulation(dt0, strat, mcdraws, dri
         benefits_stoch = sum(df[!, "valuep"])
         push!(benefits_list_optimized, benefits_stoch)
         # pass events from event_log into rule of thumb simulation
-        df = fullsimulate_with_events(dt0, (tt, state) -> get_dsoc_thumbrule1(tt, state, drive_starts_time), (tt) -> 0., 0., 0.5, 0.5, drive_starts_time, park_starts_time)
+        events = event_log
+        df = fullsimulate_with_events(dt0, (tt, state) -> get_dsoc_thumbrule1(tt, state, drive_starts_time), (tt) -> 0., 0., 0.5, 0.5, drive_starts_time, park_starts_time; events=events)
         benefits_rot = sum(df[!, "valuep"])
         push!(benefits_list_rot, benefits_rot)
-        df = fullsimulate_with_events(dt0, (tt, state) -> get_dsoc_thumbrule_baseline(tt, state, drive_starts_time), (tt) -> 0., 0., 0.5, 0.5, drive_starts_time, park_starts_time)
+        df = fullsimulate_with_events(dt0, (tt, state) -> get_dsoc_thumbrule_baseline(tt, state, drive_starts_time), (tt) -> 0., 0., 0.5, 0.5, drive_starts_time, park_starts_time; events=events)
         benefits_rot_baseline = sum(df[!, "valuep"])
         push!(benefits_list_rot_baseline, benefits_rot_baseline)
 

--- a/src/fullsim.jl
+++ b/src/fullsim.jl
@@ -128,7 +128,10 @@ function fullsimulate_modify(dt0::DateTime, strat::AbstractArray{Int}, changes::
     fullsimulate(dt0, get_dsoc, tt -> regrange[tt], vehicles_plugged_1, soc_plugged_1, soc_driving_1, stochastic)
 end
 
-function fullsimulate_with_events(dt0::DateTime, get_dsoc::Function, get_regrange::Function, vehicles_plugged_1::Float64, soc_plugged_1::Float64, soc_driving_1::Float64, drive_starts_time::Time, park_starts_time::Time)
-    fullsimulate(dt0, get_dsoc, get_regrange, vehicles_plugged_1, soc_plugged_1, soc_driving_1, drive_starts_time, park_starts_time, events=event_log)
+function fullsimulate_with_events(dt0::DateTime, get_dsoc::Function, get_regrange::Function, vehicles_plugged_1::Float64, soc_plugged_1::Float64, soc_driving_1::Float64, drive_starts_time::Time, park_starts_time::Time; events::Any=nothing)
+    if events === nothing
+        events = event_log
+    end
+    fullsimulate(dt0, get_dsoc, get_regrange, vehicles_plugged_1, soc_plugged_1, soc_driving_1, drive_starts_time, park_starts_time, events=events)
 end
 


### PR DESCRIPTION
Hi @frank-gentile! Here are some suggested edits that seemed easier to do than to describe.

I moved the code in `calc_benefits.jl` that actually does stuff, rather than just defining variables and functions, out of the `src/` directory and into a file `scripts/calc_benefits.jl`. I think that's a little cleaner.

I was also worried about `fullsimulate_with_events` diverging from the normal `fullsimulate` function, so I merged these. `fullsimulate_with_events` still exists, but it's just a wrapper on `fullsimulate`. And as such, `fullsimulate_with_events` will clear out the `event_log`, so if you want to run it multiple times with the same events, you have to pass those into it.