### PR TITLE
Working on a test for thumbrules

### DIFF
--- a/scripts/calc_benefits_regrange.jl
+++ b/scripts/calc_benefits_regrange.jl
@@ -14,5 +14,5 @@ soc_driving_1 = 0.5
 benefits = run_optimized_regrange_simulation(dt0, SS, drive_starts_time, park_starts_time)
 print("Optimized regrange benefits $(benefits)\n")
 
-benefits_rot = thumbrule_regrange(dt0, drive_starts_time, park_starts_time, drive_time_charge_level)
+benefits_rot = run_thumbrule_regrange(dt0, drive_starts_time, park_starts_time, drive_time_charge_level)
 print("Rule of thumb regrange benefits: $(benefits_rot)")

--- a/src/calc_benefits.jl
+++ b/src/calc_benefits.jl
@@ -68,6 +68,14 @@ function run_optimized_stochastic_simulation(dt0, SS, drive_starts_time, park_st
     return benefits, strat
 end
 
+function run_thumbrule_regrange(dt0, drive_starts_time, park_starts_time, drive_time_charge_level)
+    vehicles_plugged_1 = vehicles_plugged_scheduled(dt0, drive_starts_time, park_starts_time)
+
+    dsoc_func, regrange_func = thumbrule_regrange(dt0, drive_starts_time, park_starts_time, drive_time_charge_level)
+    df = fullsimulate(dt0, dsoc_func, regrange_func, vehicles_plugged_1,  0.5, 0.5, drive_starts_time, park_starts_time)
+
+    benefits = sum(df[!, "valuep"]) + sum(df[!, "valuer"])
+    return benefits
 
 function export_to_latex_benefits_table(benefits_dict)
     filename = "results/benefits_table.tex"

--- a/test/test_thumbrule.jl
+++ b/test/test_thumbrule.jl
@@ -1,0 +1,19 @@
+using Test
+
+include("../src/bizutils.jl")
+include("../src/customer.jl")
+include("../src/simulate.jl")
+include("../src/retail.jl")
+include("../src/config.jl")
+include("../src/value.jl")
+include("../src/optutils.jl")
+include("../src/fullsim.jl")
+include("../src/thumbrule.jl")
+
+dt0 = DateTime("2023-07-17T00:00:00")
+drive_starts_time = Time(9, 0, 0)  # Example drive start time
+park_starts_time = Time(17, 0, 0)  # Example park start time
+
+dsoc_func, regrange_func = thumbrule_regrange(dt0, drive_starts_time, park_starts_time, drive_time_charge_level)
+
+[regrange_func(tt) for tt in 1:36]


### PR DESCRIPTION
Hi @frank-gentile! Thank you for fixing up my last edit branch and merging it. I started this one in response to the remaining comment on the `frank_branch` PR.

The code changes here are mostly just reorganizing so that I could start a script `test_thumbrule.jl`. The idea was that we could write up some example cases where we want to make sure the thumb rule does something reasonable.

In my current test, here's the regranges that I get for the first 24 hours:
```
julia> [regrange_func(tt) for tt in 1:24]
24-element Vector{Float64}:
 52.8
 52.8
 52.8
 52.8
 52.8
 52.8
 52.8
 52.8
  0.0
  0.0
  0.0
  0.0
  0.0
  0.0
  0.0
  0.0
  0.0
 52.8
 52.8
 52.8
 52.8
 52.8
 52.8
 52.8
```

That's just giving the full regrange any time the cars are plugged in. And that's near-right, but here's my concern. Right before 9am, won't car be 80%, so we won't be able to offer the full regrange. And right after 5pm, we're not sure where the car will be-- it could be down near 30%, so we again we can't give much regrange. I think the config is set up so that we don't use anywhere near that power, but that's no better because that means at 5pm, we're still near 80%.

I think that after 5pm, we need to ramp up regrange from the worst-likely-case, as charge puts us where we want to be; and before 9am, we need to ramp-down regrange since we're forced to move out of the ideal regrange SOC.

I might be wrong about this-- maybe we can give this regrange because we can charge/discharge fast enough. I didn't finish the test. But can you take a look?