### PR TITLE
investigate weird behavior 8/4

### DIFF
--- a/rcode/valuecomp.R
+++ b/rcode/valuecomp.R
@@ -12,6 +12,15 @@ dir.create("plots_R_regrange", showWarnings = FALSE, recursive = TRUE)
 
 df <- read.csv("results/bytime_regrange.csv")
 
+## Total value of each component over the whole simulated horizon, by approach
+totals <- df %>% group_by(Approach) %>%
+    summarize(`Power costs`=sum(valuep), `State penalty`=sum(valuepns),
+              `Energy level`=sum(valuee), `Regulation payment`=sum(valuer),
+              Total=sum(valuep + valuepns + valuee + valuer))
+
+cat("\nTotal value by approach, ", min(df$datetime), " to ", max(df$datetime), ":\n", sep="")
+print(as.data.frame(totals), row.names=FALSE, digits=4)
+
 df2 <- df %>% filter(as.Date(datetime) == "2023-07-17") %>%
     pivot_longer(cols=c('valuep', 'valuepns', 'valuee', 'valuer'))
 df2$label <- unlist(list('valuep'="Power costs", 'valuee'="Energy level",

--- a/scripts/compare_benefits_regrange.jl
+++ b/scripts/compare_benefits_regrange.jl
@@ -56,8 +56,21 @@ end
 CSV.write("results/bytime-xstart.csv", vcat(alldf...))
 
 
-## TODO: Create same plots for regrange benefits
+##
+include("../src/calc_benefits.jl")
 
+SS = 36
+global mcdraws = 1
+dt0 = DateTime("2023-07-17T00:00:00")
+drive_starts_time = Time(9, 0, 0)  # Example drive start time
+park_starts_time = Time(17, 0, 0)  # Example park start time
+
+soc_plugged_1 = 0.5
+soc_driving_1 = 0.5
+
+RR = 5 # number of possible regrange values
+probfail_penalty = 10.
+portion_below_penalty = 100.
 vehicles_plugged_1 = vehicles_plugged_scheduled(dt0 + periodstep(1), drive_starts_time, park_starts_time)
 
 strat, probfail, regrange = optimize_regrange_double_outer_loop(dt0, soc_plugged_1, soc_driving_1, vehicles_plugged_1, drive_starts_time, park_starts_time);
@@ -76,8 +89,8 @@ df3 = fullsimulate(dt0, (tt, state) -> get_dsoc_thumbrule_baseline(tt, state, dr
 df3[!, :Approach] .= "Baseline"
 df3[!, :regrange_kw] = zeros(SS)  # Baseline offers no regulation
 
-CSV.write("../results/bytime_regrange.csv", [df1; df2; df3])
-
+CSV.write("results/bytime_regrange.csv", [df1; df2; df3]) # where rcode/valuecomp.R and rcode/plot_soc_regrange.* read it from
+##
 alldf = []
 for drive_starts_hour in 1:23
     println(drive_starts_hour)

--- a/src/fullsim.jl
+++ b/src/fullsim.jl
@@ -12,12 +12,12 @@ Simulates the energy fraction of vehicles while applying a given changes in ener
 - `stochastic::Bool=false`: Optional argument to enable stochastic simulation of energy needs.
 
 # Returns
-- `DataFrame`: A DataFrame containing columns for each timestep including datetime, needed energy fraction, fractions and energy below and above threshold, plugged and driving vehicle energy, energy fraction change (`dsoc`), and state representation.
+- `DataFrame`: A DataFrame containing columns for each timestep including datetime, needed energy fraction, fractions and energy below and above threshold before and after the action (`_2` suffix), plugged and driving vehicle energy, energy fraction change (`dsoc`), and state representation.
 """
 function fullsimulate(dt0::DateTime, get_dsoc::Function, get_regrange::Function, vehicles_plugged_1::Float64, soc_plugged_1::Float64, soc_driving_1::Float64, drive_starts_time::Time, park_starts_time::Time, stochastic::Bool=false; events::Any=nothing)
     global event_log = [] ## clear out event_log before simulating
     ## vehicles_plugged_1, soc_plugged_1, soc_driving_1 = 0., 0.5, 0.5 # debugging
-    rows = Tuple{DateTime, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Union{Missing, Float64}, Union{Missing, Tuple{Int, Int, Int}}, Float64, Float64, Float64, Float64}[]
+    rows = Tuple{DateTime, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Union{Missing, Float64}, Union{Missing, Tuple{Int, Int, Int}}, Float64, Float64, Float64, Float64}[]
 
     soc_needed = soc_scheduled(dt0 + periodstep(1), drive_starts_time)
     vehicle_split = split_below(soc_plugged_1, soc_needed)
@@ -29,17 +29,25 @@ function fullsimulate(dt0::DateTime, get_dsoc::Function, get_regrange::Function,
         dt1 = dt0 + periodstep(tt)
         price = get_retail_price(dt1)
 
-        valuep = value_power_action(price, dsoc, vehicle_split[1], vehicles_plugged_1)
-        valuepns = value_power_newstate(price, vehicle_split[1], soc_needed - vehicle_split[2], vehicles_plugged_1)
-        valuee = value_energy(vehicle_split[1], vehicle_split[3], soc_needed, vehicles_plugged_1)
+        ## Apply action
+        soc_plugged_2 = soc_plugged_1 + dsoc
+
+        ## Split the fleet *after* the action: these are the vehicles that adjust_below then
+        ## force-charges at fracpower_max, so this is the split the action must be valued
+        ## against. Valuing against the pre-action split lets a discharge collect its revenue
+        ## while the resulting recharge is never paid for. Matches the optimizer, which
+        ## values valuepns/valuee and penalizes portion_below on the post-action state.
+        soc_needed_2 = soc_scheduled(dt1, drive_starts_time)
+        vehicle_split_2 = split_below(soc_plugged_2, soc_needed_2)
+
+        valuep = value_power_action(price, dsoc, vehicle_split_2[1], vehicles_plugged_1)
+        valuepns = value_power_newstate(price, vehicle_split_2[1], soc_needed_2 - vehicle_split_2[2], vehicles_plugged_1)
+        valuee = value_energy(vehicle_split_2[1], vehicle_split_2[3], soc_needed_2, vehicles_plugged_1)
 
         regprice = avg_regprice_byhour[hour(dt1)]
         valuer = regprice * get_regrange(tt) / regneutral
 
-        push!(rows, (dt0 + periodstep(tt), soc_needed, vehicles_plugged_1, vehicle_split[1], vehicle_split[2], vehicle_split[3], soc_plugged_1, soc_driving_1, dsoc, statebase, valuep, valuepns, valuee, valuer))
-
-        ## Apply action
-        soc_plugged_2 = soc_plugged_1 + dsoc
+        push!(rows, (dt0 + periodstep(tt), soc_needed, vehicles_plugged_1, vehicle_split[1], vehicle_split[2], vehicle_split[3], vehicle_split_2[1], vehicle_split_2[2], vehicle_split_2[3], soc_plugged_1, soc_driving_1, dsoc, statebase, valuep, valuepns, valuee, valuer))
 
         ## Apply simulation
         if events !== nothing
@@ -68,17 +76,17 @@ function fullsimulate(dt0::DateTime, get_dsoc::Function, get_regrange::Function,
             simustep = get_simustep_deterministic(dt1, drive_starts_time, park_starts_time)
         end
 
-        soc_needed = soc_scheduled(dt1, drive_starts_time)
-        vehicle_split = split_below(soc_plugged_2, soc_needed)
+        soc_needed = soc_needed_2
+        vehicle_split = vehicle_split_2
         vehicles_plugged_2, soc_plugged_2, soc_driving_2 = adjust_below(simustep(vehicles_plugged_1, vehicles_plugged_1 * (1. - vehicle_split[1]), soc_plugged_2, soc_driving_1), vehicle_split[2], vehicles_plugged_1 * vehicle_split[1])
         vehicles_plugged_1, soc_plugged_1, soc_driving_1 = vehicles_plugged_2, soc_plugged_2, soc_driving_2
         vehicle_split = split_below(soc_plugged_2, soc_needed)
     end
 
-    push!(rows, (dt0 + periodstep(SS), soc_needed, vehicles_plugged_1, vehicle_split[1], vehicle_split[2], vehicle_split[3], soc_plugged_1, soc_driving_1, missing, missing, 0., 0., 0., 0.))
+    push!(rows, (dt0 + periodstep(SS), soc_needed, vehicles_plugged_1, vehicle_split[1], vehicle_split[2], vehicle_split[3], vehicle_split[1], vehicle_split[2], vehicle_split[3], soc_plugged_1, soc_driving_1, missing, missing, 0., 0., 0., 0.))
 
     df = DataFrame(rows)
-    rename!(df, [:datetime, :soc_needed, :vehicles_plugged, :portion_below, :soc_below, :soc_above, :soc_plugged, :soc_driving, :dsoc, :state, :valuep, :valuepns, :valuee, :valuer])
+    rename!(df, [:datetime, :soc_needed, :vehicles_plugged, :portion_below, :soc_below, :soc_above, :portion_below_2, :soc_below_2, :soc_above_2, :soc_plugged, :soc_driving, :dsoc, :state, :valuep, :valuepns, :valuee, :valuer])
 end
 
 function fullsimulate(dt0::DateTime, strat::AbstractArray{Int}, regrange::Vector{Float64}, vehicles_plugged_1::Float64, soc_plugged_1::Float64, soc_driving_1::Float64, drive_starts_time::Time, park_starts_time::Time, stochastic::Bool=false)

--- a/src/optfuncs.jl
+++ b/src/optfuncs.jl
@@ -388,9 +388,11 @@ function optimize_regrange_given(dt0::DateTime, regrange::Vector{Float64},  driv
 end
 
 function given_calcvalue(df, regrange, dt0)
-    df[!, :kw] = (df.dsoc .* vehicle_capacity .* df.vehicles_plugged .* (1 .- df.portion_below) / timestep) .+
-        (max_charging_kw * df.portion_below .* df.vehicles_plugged) .+ regrange
-    sum(df.valuep .+ df.valuepns .+ df.valuee .+ df.valuer .- portion_below_penalty * sqrt.(df.portion_below)) -
+    ## Use the post-action split: it determines which vehicles adjust_below force-charges, so
+    ## it is what the demand charge and the below-threshold penalty must be assessed against.
+    df[!, :kw] = (df.dsoc .* vehicle_capacity .* df.vehicles_plugged .* (1 .- df.portion_below_2) / timestep) .+
+        (max_charging_kw * df.portion_below_2 .* df.vehicles_plugged) .+ regrange
+    sum(df.valuep .+ df.valuepns .+ df.valuee .+ df.valuer .- portion_below_penalty * sqrt.(df.portion_below_2)) -
         get_demand_cost(dt0, collect(skipmissing(df.kw)), timestep)
 end
 


### PR DESCRIPTION
In valuecomp.R, it just adds a simple calculation to sum up the value and print out for each scenario. 
In compare_benefits_regrange.jl I just added the constants in the second block to be able to just run that cell 
In fullsim.jl it seems like the optimizer learned to discharge for free and it has no impact on the SOC. So the idea would be to apply the action to calculate the new SOC before calculating the benefits
In optfuncs.jl adjust for the naming convention